### PR TITLE
Bump spring-core in /examples/active-aggregator-example

### DIFF
--- a/examples/active-aggregator-example/pom.xml
+++ b/examples/active-aggregator-example/pom.xml
@@ -226,7 +226,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-			<version>5.3.14</version>
+			<version>5.3.19</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
**A temporary PR to see what is the result of Github CI/CD and Sonarcloud.**

Bumps [spring-core](https://github.com/spring-projects/spring-framework) from 5.3.14 to 5.3.19.
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.3.14...v5.3.19)

---
updated-dependencies:
- dependency-name: org.springframework:spring-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>