### PR TITLE
Bump spring-core from 5.3.14 to 5.3.19 in /examples/active-aggregator-example

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - develop
     paths-ignore:
       - .github/**
   pull_request:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,6 +33,15 @@ jobs:
         gpg-private-key: ${{ secrets.OSSRH_PGP_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
+    - name: Set up Maven cache
+      uses: actions/cache@v1
+      if: github.event_name != 'push' || github.ref != 'refs/heads/master'
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
     - name: Build and verify with Maven
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/active-aggregator-example/pom.xml
+++ b/examples/active-aggregator-example/pom.xml
@@ -226,7 +226,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-			<version>5.3.14</version>
+			<version>5.3.19</version>
 		</dependency>
 	</dependencies>
 

--- a/examples/active-aggregator-example/pom.xml
+++ b/examples/active-aggregator-example/pom.xml
@@ -18,6 +18,7 @@
 		<mule.http.connector.version>1.5.0</mule.http.connector.version>
 		<munit.version>2.3.1</munit.version>
 		<app.runtime>4.2.1-hf3</app.runtime>
+		<argLine>-Djava.awt.headless=true</argLine>
 	</properties>
 	
 	<build>
@@ -86,7 +87,6 @@
 				<configuration>
 					<argLines>
 						<argLine>${surefire.jacoco.args}</argLine>
-						<argLine>-Djava.awt.headless=true</argLine>
 					</argLines>
 				</configuration>
 			</plugin>

--- a/examples/passive-splitter-example/pom.xml
+++ b/examples/passive-splitter-example/pom.xml
@@ -18,6 +18,7 @@
 		<mule.http.connector.version>1.5.0</mule.http.connector.version>
 		<munit.version>2.3.1</munit.version>
 		<app.runtime>4.2.1-hf3</app.runtime>
+		<argLine>-Djava.awt.headless=false</argLine>
 	</properties>
 
 	<build>
@@ -66,7 +67,6 @@
 				<configuration>
 					<argLines>
 						<argLine>${surefire.jacoco.args}</argLine>
-						<argLine>-Djava.awt.headless=true</argLine>
 					</argLines>
 				</configuration>
 			</plugin>

--- a/examples/passive-splitter-example/pom.xml
+++ b/examples/passive-splitter-example/pom.xml
@@ -18,7 +18,7 @@
 		<mule.http.connector.version>1.5.0</mule.http.connector.version>
 		<munit.version>2.3.1</munit.version>
 		<app.runtime>4.2.1-hf3</app.runtime>
-		<argLine>-Djava.awt.headless=false</argLine>
+		<argLine>-Djava.awt.headless=true</argLine>
 	</properties>
 
 	<build>

--- a/mule-bpm-dummy-flowable-activity/pom.xml
+++ b/mule-bpm-dummy-flowable-activity/pom.xml
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/mule-bpm-flowable-activity/pom.xml
+++ b/mule-bpm-flowable-activity/pom.xml
@@ -73,6 +73,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.4</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/mule-bpm-module/pom.xml
+++ b/mule-bpm-module/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <argLine>-Djava.awt.headless=false</argLine>
+        <argLine>-Djava.awt.headless=true</argLine>
     </properties>
 
     <build>

--- a/mule-bpm-module/pom.xml
+++ b/mule-bpm-module/pom.xml
@@ -43,6 +43,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
+        <argLine>-Djava.awt.headless=false</argLine>
     </properties>
 
     <build>
@@ -67,18 +68,14 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
-
                     <systemProperties>
                         <property>
                             <name>mule.test.timeoutSecs</name>
                             <value>120</value>
                         </property>
                     </systemProperties>
-
-                    <argLine>-Djava.awt.headless=true</argLine>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
**Note: remade the PR to avoid dependabot gpg issues**

Bumps [spring-core](https://github.com/spring-projects/spring-framework) from 5.3.14 to 5.3.19.
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.3.14...v5.3.19)

---
updated-dependencies:
- dependency-name: org.springframework:spring-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>